### PR TITLE
Change Keyboard Key Colors

### DIFF
--- a/src/app/key/key.component.html
+++ b/src/app/key/key.component.html
@@ -1,6 +1,6 @@
 <div class="key" id="key-{{key}}">
-    <button [ngClass]="isLargeButton(key)
-    ? 'large-btn'
-    : 'small-btn' "
-    (click)="onKeyClick(key)">{{key}}</button>
+    <button [class.light-grey]="(keyColor$| async) === 'light-grey'"
+        [class.dark-grey]="(keyColor$| async) === 'dark-grey'" [class.yellow]="(keyColor$| async) === 'yellow'"
+        [class.green]="(keyColor$| async) === 'green'" [class.large-btn]="isLargeButton(key)"
+        [class.small-btn]="!isLargeButton(key)" (click)="onKeyClick(key)">{{key}}</button>
 </div>

--- a/src/app/key/key.component.html
+++ b/src/app/key/key.component.html
@@ -1,6 +1,3 @@
 <div class="key" id="key-{{key}}">
-    <button [class.light-grey]="(keyColor$| async) === 'light-grey'"
-        [class.dark-grey]="(keyColor$| async) === 'dark-grey'" [class.yellow]="(keyColor$| async) === 'yellow'"
-        [class.green]="(keyColor$| async) === 'green'" [class.large-btn]="isLargeButton(key)"
-        [class.small-btn]="!isLargeButton(key)" (click)="onKeyClick(key)">{{key}}</button>
+    <button [class]="[buttonSize, gameplayService.evaluateKey$(key) | async]" (click)="onKeyClick(key)">{{key}}</button>
 </div>

--- a/src/app/key/key.component.scss
+++ b/src/app/key/key.component.scss
@@ -28,18 +28,18 @@ button {
     width: 2.75rem;
 }
 
-.light-grey {
+.no-score {
     background-color: $light-grey;
 }
 
-.dark-grey {
+.incorrect {
     background-color: $dark-grey;
 }
 
-.yellow {
+.in-word {
     background-color: $yellow;
 }
 
-.green {
+.correct {
     background-color: $green;
 }

--- a/src/app/key/key.component.scss
+++ b/src/app/key/key.component.scss
@@ -1,27 +1,45 @@
-$primary-key-color: #EFEFEF;
-$hover-key-color: darken($primary-key-color, 5%);
+$hover-key-color: brightness(0.95);
+$dark-grey: #787c7f;
+$light-grey: #EFEFEF;
+$green: #6ca965;
+$yellow: #c8b653;
 
 .key {
     display: inherit;
     flex-wrap: wrap;
     margin: 2px;
+}
 
-    button {
-        border: none;
-        border-radius: 4px;
-        height: 3.75rem;
-        background-color: $primary-key-color;
+button {
+    border: none;
+    border-radius: 4px;
+    height: 3.75rem;
 
-        &:hover {
-            background-color: $hover-key-color;
-        }
+    &:hover {
+        filter: $hover-key-color;
     }
+}
 
-    .large-btn {
-        width: 4rem;
-    }
+.large-btn {
+    width: 4rem;
+}
 
-    .small-btn {
-        width: 2.75rem;
-    }
+.small-btn {
+    width: 2.75rem;
+}
+
+.light-grey {
+    background-color: $light-grey;
+}
+
+.dark-grey {
+    background-color: $dark-grey;
+}
+
+.yellow {
+    background-color: $yellow;
+}
+
+.green {
+    background-color: $green;
 }

--- a/src/app/key/key.component.spec.ts
+++ b/src/app/key/key.component.spec.ts
@@ -6,7 +6,7 @@ import { KeyComponent } from './key.component';
 import { GamePlayService } from '../services/game-play.service';
 import { AnswerService } from '../services/answer.service';
 import { Answer } from '../models/answer';
-import { KeyColor } from './key.component';
+import { LetterScore } from '../models/letter-score';
 
 let component: KeyComponent;
 let fixture: ComponentFixture<KeyComponent>;
@@ -54,13 +54,13 @@ describe('KeyComponent - ENTER Key', () => {
     expect(compiled.querySelector('.large-btn')?.textContent).toEqual('ENTER');
   });
 
-  it('should assign light-grey key color for the ENTER key', async () => {
+  it('should have .no-score class for the ENTER key', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('ENTER');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('ENTER');
   });
 
-  it('should not change the key color for the ENTER key after a new guess is submitted', async () => {
+  it('should not change the key class for the ENTER key after a new guess is submitted', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const enterGuess = 'ENTER';
 
@@ -68,8 +68,8 @@ describe('KeyComponent - ENTER Key', () => {
     service.submitGuess();
     fixture.detectChanges();
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('ENTER');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('ENTER');
 
   });
 });
@@ -112,13 +112,13 @@ describe('KeyComponent - DELETE Key', () => {
     expect(compiled.querySelector('.large-btn')?.textContent).toEqual('DELETE');
   });
 
-  it('should assign light-grey key color for the DELETE key', async () => {
+  it('should have .no-score class for the DELETE key', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('DELETE');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('DELETE');
   });
 
-  it('should not change key color for the DELETE key', async () => {
+  it('should not change key class for the DELETE key given new accepted guess', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const enterGuess = 'DELTS';
 
@@ -126,8 +126,8 @@ describe('KeyComponent - DELETE Key', () => {
     service.submitGuess();
     fixture.detectChanges();
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('DELETE');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('DELETE');
 
   });
 });
@@ -170,34 +170,34 @@ describe('KeyComponent - A Key', () => {
     expect(compiled.querySelector(`#key-A`)?.textContent).toContain('A')
   });
 
-  it('should set key class to .yellow when SPARE is an accepted guess', async () => {
+  it('should set key class to in-word when SPARE is an accepted guess', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('A');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('A');
 
     const newGuess = 'SPARE';
     callAddLetters(newGuess);
     service.submitGuess();
     fixture.detectChanges();
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.yellow);
-    expect(compiled.querySelector('.yellow')?.textContent).toEqual('A');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.inWord);
+    expect(compiled.querySelector('.in-word')?.textContent).toEqual('A');
   });
 
-  it('should set key class to .green when ADEPT is an accepted guess', async () => {
+  it('should set key class to .correct when ADEPT is an accepted guess', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('A');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('A');
 
     const correctGuess = 'ADEPT';
     callAddLetters(correctGuess);
     service.submitGuess();
     fixture.detectChanges();
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.green);
-    expect(compiled.querySelector('.green')?.textContent).toEqual('A');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.correct);
+    expect(compiled.querySelector('.correct')?.textContent).toEqual('A');
   });
 });
 
@@ -239,18 +239,18 @@ describe('KeyComponent - Q Key', () => {
     expect(compiled.querySelector(`#key-Q`)?.textContent).toContain('Q')
   });
 
-  it('should set key class to .dark-grey when a Q is guessed but not in answer', async () => {
+  it('should set key class to .incorrect when a Q is guessed but not in answer', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
-    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('Q');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.scoreless);
+    expect(compiled.querySelector('.no-score')?.textContent).toEqual('Q');
 
     const newGuess = 'QUIET';
     callAddLetters(newGuess);
     service.submitGuess();
     fixture.detectChanges();
 
-    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.darkGrey);
-    expect(compiled.querySelector('.dark-grey')?.textContent).toEqual('Q');
+    expect(await firstValueFrom(service.evaluateKey$(component.key))).toEqual(LetterScore.notInWord);
+    expect(compiled.querySelector('.incorrect')?.textContent).toEqual('Q');
   });
 });

--- a/src/app/key/key.component.spec.ts
+++ b/src/app/key/key.component.spec.ts
@@ -1,18 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { KeyComponent } from './key.component';
+import { GamePlayService } from '../services/game-play.service';
 
 describe('KeyComponent', () => {
   let component: KeyComponent;
   let fixture: ComponentFixture<KeyComponent>;
+  let service: GamePlayService;
   const keys: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', 'A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'ENTER', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', 'DELETE'];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [KeyComponent]
+      declarations: [KeyComponent],
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [GamePlayService]
     });
     fixture = TestBed.createComponent(KeyComponent);
     component = fixture.componentInstance;
+    service = TestBed.inject(GamePlayService);
     fixture.detectChanges();
   });
 
@@ -23,13 +31,15 @@ describe('KeyComponent', () => {
   it('should assign a specific large button class for the ENTER and DELETE keys', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     fixture.whenStable().then(() => {
-      expect(compiled.querySelector('.large-btw')?.textContent).toContain('ENTER' || 'DELETE');
+      expect(compiled.querySelector('.large-btn')?.textContent).toContain('ENTER' || 'DELETE');
     });
   });
   it('should render each key with a unique id', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     fixture.whenStable().then(() => {
+      console.log(compiled.querySelector(`#key-N`)?.textContent);
       keys.forEach(key =>
+        // console.log(compiled.querySelector(`#key-${key}`)?.textContent)
         expect(compiled.querySelector(`#key-${key}`)?.textContent).toContain(key)
       )
     });

--- a/src/app/key/key.component.spec.ts
+++ b/src/app/key/key.component.spec.ts
@@ -1,25 +1,41 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, firstValueFrom } from 'rxjs';
 
 import { KeyComponent } from './key.component';
 import { GamePlayService } from '../services/game-play.service';
+import { AnswerService } from '../services/answer.service';
+import { Answer } from '../models/answer';
+import { KeyColor } from './key.component';
 
-describe('KeyComponent', () => {
-  let component: KeyComponent;
-  let fixture: ComponentFixture<KeyComponent>;
-  let service: GamePlayService;
-  const keys: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', 'A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'ENTER', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', 'DELETE'];
+let component: KeyComponent;
+let fixture: ComponentFixture<KeyComponent>;
+let service: GamePlayService;
+const mockAnswer: Answer = { id: 1, word: 'ADEPT' };
+const callAddLetters = (letters: string) => {
+  for (let i = 0; i < letters.length; i++) service.addLetter(letters[i]);
+};
 
+describe('KeyComponent - ENTER Key', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [KeyComponent],
       imports: [
         HttpClientTestingModule
       ],
-      providers: [GamePlayService]
+      providers: [
+        GamePlayService,
+        {
+          provide: AnswerService,
+          useValue: <Partial<AnswerService>>{
+            getAnswer: jest.fn().mockReturnValue(of(mockAnswer))
+          }
+        }
+      ]
     });
     fixture = TestBed.createComponent(KeyComponent);
     component = fixture.componentInstance;
+    component.key = 'ENTER';
     service = TestBed.inject(GamePlayService);
     fixture.detectChanges();
   });
@@ -28,20 +44,213 @@ describe('KeyComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should assign a specific large button class for the ENTER and DELETE keys', () => {
+  it('should display key input', () => {
     const compiled = fixture.nativeElement as HTMLElement;
-    fixture.whenStable().then(() => {
-      expect(compiled.querySelector('.large-btn')?.textContent).toContain('ENTER' || 'DELETE');
-    });
+    expect(compiled.querySelector('button')?.textContent).toEqual('ENTER')
   });
+
+  it('should assign a large button class to the ENTER key', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.large-btn')?.textContent).toEqual('ENTER');
+  });
+
+  it('should assign light-grey key color for the ENTER key', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('ENTER');
+  });
+
+  it('should not change the key color for the ENTER key after a new guess is submitted', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const enterGuess = 'ENTER';
+
+    callAddLetters(enterGuess);
+    service.submitGuess();
+    fixture.detectChanges();
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('ENTER');
+
+  });
+});
+
+describe('KeyComponent - DELETE Key', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [KeyComponent],
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        GamePlayService,
+        {
+          provide: AnswerService,
+          useValue: <Partial<AnswerService>>{
+            getAnswer: jest.fn().mockReturnValue(of(mockAnswer))
+          }
+        }
+      ]
+    });
+    fixture = TestBed.createComponent(KeyComponent);
+    component = fixture.componentInstance;
+    component.key = 'DELETE';
+    service = TestBed.inject(GamePlayService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display key input', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('button')?.textContent).toEqual('DELETE')
+  });
+
+  it('should assign a large button class to the DELETE key', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.large-btn')?.textContent).toEqual('DELETE');
+  });
+
+  it('should assign light-grey key color for the DELETE key', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('DELETE');
+  });
+
+  it('should not change key color for the DELETE key', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const enterGuess = 'DELTS';
+
+    callAddLetters(enterGuess);
+    service.submitGuess();
+    fixture.detectChanges();
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('DELETE');
+
+  });
+});
+
+describe('KeyComponent - A Key', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [KeyComponent],
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        GamePlayService,
+        {
+          provide: AnswerService,
+          useValue: <Partial<AnswerService>>{
+            getAnswer: jest.fn().mockReturnValue(of(mockAnswer))
+          }
+        }
+      ]
+    });
+    fixture = TestBed.createComponent(KeyComponent);
+    component = fixture.componentInstance;
+    component.key = 'A';
+    service = TestBed.inject(GamePlayService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display key Input in button', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('button')?.textContent).toEqual('A');
+  });
+
   it('should render each key with a unique id', () => {
     const compiled = fixture.nativeElement as HTMLElement;
-    fixture.whenStable().then(() => {
-      console.log(compiled.querySelector(`#key-N`)?.textContent);
-      keys.forEach(key =>
-        // console.log(compiled.querySelector(`#key-${key}`)?.textContent)
-        expect(compiled.querySelector(`#key-${key}`)?.textContent).toContain(key)
-      )
+    expect(compiled.querySelector(`#key-A`)?.textContent).toContain('A')
+  });
+
+  it('should set key class to .yellow when SPARE is an accepted guess', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('A');
+
+    const newGuess = 'SPARE';
+    callAddLetters(newGuess);
+    service.submitGuess();
+    fixture.detectChanges();
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.yellow);
+    expect(compiled.querySelector('.yellow')?.textContent).toEqual('A');
+  });
+
+  it('should set key class to .green when ADEPT is an accepted guess', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('A');
+
+    const correctGuess = 'ADEPT';
+    callAddLetters(correctGuess);
+    service.submitGuess();
+    fixture.detectChanges();
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.green);
+    expect(compiled.querySelector('.green')?.textContent).toEqual('A');
+  });
+});
+
+describe('KeyComponent - Q Key', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [KeyComponent],
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        GamePlayService,
+        {
+          provide: AnswerService,
+          useValue: <Partial<AnswerService>>{
+            getAnswer: jest.fn().mockReturnValue(of(mockAnswer))
+          }
+        }
+      ]
     });
+    fixture = TestBed.createComponent(KeyComponent);
+    component = fixture.componentInstance;
+    component.key = 'Q';
+    service = TestBed.inject(GamePlayService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display key Input in button', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('button')?.textContent).toEqual('Q');
+  });
+
+  it('should render each key with a unique id', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector(`#key-Q`)?.textContent).toContain('Q')
+  });
+
+  it('should set key class to .dark-grey when a Q is guessed but not in answer', async () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.lightGrey);
+    expect(compiled.querySelector('.light-grey')?.textContent).toEqual('Q');
+
+    const newGuess = 'QUIET';
+    callAddLetters(newGuess);
+    service.submitGuess();
+    fixture.detectChanges();
+
+    expect(await firstValueFrom(component.keyColor$)).toEqual(KeyColor.darkGrey);
+    expect(compiled.querySelector('.dark-grey')?.textContent).toEqual('Q');
   });
 });

--- a/src/app/key/key.component.ts
+++ b/src/app/key/key.component.ts
@@ -1,15 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
-import { Observable, distinctUntilChanged, map } from 'rxjs';
 
 import { GamePlayService } from '../services/game-play.service';
-import { KeyScore } from '../models/key-score';
-
-export enum KeyColor {
-  darkGrey = 'dark-grey',
-  lightGrey = 'light-grey',
-  green = 'green',
-  yellow = 'yellow'
-}
 
 @Component({
   selector: 'app-key',
@@ -17,7 +8,7 @@ export enum KeyColor {
   styleUrls: ['./key.component.scss']
 })
 export class KeyComponent implements OnInit {
-  public keyColor$!: Observable<KeyColor>;
+  public buttonSize!: string;
 
   @Input() public key!: string;
   @Output() keyClick = new EventEmitter<string>();
@@ -25,20 +16,7 @@ export class KeyComponent implements OnInit {
   constructor(protected readonly gameplayService: GamePlayService) { }
 
   ngOnInit(): void {
-    this.keyColor$ = this.gameplayService.evaluateKey$(this.key).pipe(
-      distinctUntilChanged(),
-      map(val => {
-        if (val === KeyScore.notInWord) return KeyColor.darkGrey;
-        if (val === KeyScore.inWord) return KeyColor.yellow;
-        if (val === KeyScore.correct) return KeyColor.green;
-
-        return KeyColor.lightGrey;
-      })
-    )
-  }
-
-  protected isLargeButton(key: string): boolean {
-    return key === 'ENTER' || key === 'DELETE';
+    this.buttonSize = this.key === 'ENTER' || this.key === 'DELETE' ? 'large-btn' : 'small-btn';
   }
 
   public onKeyClick(key: string) {

--- a/src/app/key/key.component.ts
+++ b/src/app/key/key.component.ts
@@ -1,13 +1,41 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Observable, distinctUntilChanged, map } from 'rxjs';
+
+import { GamePlayService } from '../services/game-play.service';
+import { KeyScore } from '../models/key-score';
+
+export enum KeyColor {
+  darkGrey = 'dark-grey',
+  lightGrey = 'light-grey',
+  green = 'green',
+  yellow = 'yellow'
+}
 
 @Component({
   selector: 'app-key',
   templateUrl: './key.component.html',
   styleUrls: ['./key.component.scss']
 })
-export class KeyComponent {
+export class KeyComponent implements OnInit {
+  protected keyColor$!: Observable<KeyColor>;
+
   @Input() public key!: string;
   @Output() keyClick = new EventEmitter<string>();
+
+  constructor(protected readonly gameplayService: GamePlayService) { }
+
+  ngOnInit(): void {
+    this.keyColor$ = this.gameplayService.evaluateKey$(this.key).pipe(
+      distinctUntilChanged(),
+      map(val => {
+        if (val === KeyScore.notInWord) return KeyColor.darkGrey;
+        if (val === KeyScore.inWord) return KeyColor.yellow;
+        if (val === KeyScore.correct) return KeyColor.green;
+
+        return KeyColor.lightGrey;
+      })
+    )
+  }
 
   protected isLargeButton(key: string): boolean {
     return key === 'ENTER' || key === 'DELETE';

--- a/src/app/key/key.component.ts
+++ b/src/app/key/key.component.ts
@@ -17,7 +17,7 @@ export enum KeyColor {
   styleUrls: ['./key.component.scss']
 })
 export class KeyComponent implements OnInit {
-  protected keyColor$!: Observable<KeyColor>;
+  public keyColor$!: Observable<KeyColor>;
 
   @Input() public key!: string;
   @Output() keyClick = new EventEmitter<string>();

--- a/src/app/keyboard/keyboard.component.spec.ts
+++ b/src/app/keyboard/keyboard.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { KeyboardComponent } from './keyboard.component';
 import { KeyComponent } from '../key/key.component';
@@ -12,7 +13,10 @@ describe('KeyboardComponent', () => {
       declarations: [
         KeyboardComponent,
         KeyComponent
-      ]
+      ],
+      imports: [
+        HttpClientTestingModule
+      ],
     });
     fixture = TestBed.createComponent(KeyboardComponent);
     component = fixture.componentInstance;

--- a/src/app/models/key-score.ts
+++ b/src/app/models/key-score.ts
@@ -1,6 +1,0 @@
-export enum KeyScore {
-    correct,
-    inWord,
-    notInWord,
-    unused
-}

--- a/src/app/models/letter-score.ts
+++ b/src/app/models/letter-score.ts
@@ -1,0 +1,6 @@
+export enum LetterScore {
+    correct = "correct",
+    inWord = "in-word",
+    notInWord = "incorrect",
+    scoreless = "no-score"
+}

--- a/src/app/services/game-play.service.spec.ts
+++ b/src/app/services/game-play.service.spec.ts
@@ -5,7 +5,7 @@ import { firstValueFrom, of } from 'rxjs';
 import { GamePlayService } from './game-play.service';
 import { AnswerService } from './answer.service';
 import { Answer } from '../models/answer';
-import { KeyScore } from '../models/key-score';
+import { LetterScore } from '../models/letter-score';
 
 const mockAnswer: Answer = { id: 1, word: 'ADEPT' }
 
@@ -96,25 +96,25 @@ describe('GamePlayService', () => {
     expect(await firstValueFrom(service.currentGuessIdx$)).toEqual(0);
     expect(await firstValueFrom(service.currentGuess$)).toEqual(invalidGuess);
   });
-  it('should return key scores for A, T, C, and Q keys when ACTED is guessed', async () => {
+  it('should return letter scores for A, T, C, and Q keys when ACTED is guessed', async () => {
     const wrongGuess = 'ACTED';
 
     callAddLetters(wrongGuess);
     service.submitGuess();
 
-    expect(await firstValueFrom(service.evaluateKey$('A'))).toEqual(KeyScore.correct);
-    expect(await firstValueFrom(service.evaluateKey$('T'))).toEqual(KeyScore.inWord);
-    expect(await firstValueFrom(service.evaluateKey$('C'))).toEqual(KeyScore.notInWord);
-    expect(await firstValueFrom(service.evaluateKey$('Q'))).toEqual(KeyScore.unused);
+    expect(await firstValueFrom(service.evaluateKey$('A'))).toEqual(LetterScore.correct);
+    expect(await firstValueFrom(service.evaluateKey$('T'))).toEqual(LetterScore.inWord);
+    expect(await firstValueFrom(service.evaluateKey$('C'))).toEqual(LetterScore.notInWord);
+    expect(await firstValueFrom(service.evaluateKey$('Q'))).toEqual(LetterScore.scoreless);
   });
 
-  it('should always return the KeyScore unused for ENTER and DELETE', async () => {
+  it('should always return the LetterScore scoreless for ENTER and DELETE', async () => {
     const enterGuess = 'ENTER';
 
     callAddLetters(enterGuess);
     service.submitGuess();
 
-    expect(await firstValueFrom(service.evaluateKey$('ENTER'))).toEqual(KeyScore.unused);
-    expect(await firstValueFrom(service.evaluateKey$('DELETE'))).toEqual(KeyScore.unused);
+    expect(await firstValueFrom(service.evaluateKey$('ENTER'))).toEqual(LetterScore.scoreless);
+    expect(await firstValueFrom(service.evaluateKey$('DELETE'))).toEqual(LetterScore.scoreless);
   });
 });

--- a/src/app/services/game-play.service.ts
+++ b/src/app/services/game-play.service.ts
@@ -6,7 +6,7 @@ import { AnswerService } from './answer.service';
 import { Answer } from '../models/answer';
 import { Logger } from './log.service';
 import { Status } from '../models/game';
-import { KeyScore } from '../models/key-score';
+import { LetterScore } from '../models/letter-score';
 
 interface Game {
   answer?: Answer;
@@ -84,7 +84,7 @@ export class GamePlayService {
     })
   }
 
-  public evaluateKey$(key: string): Observable<KeyScore> {
+  public evaluateKey$(key: string): Observable<LetterScore> {
     return combineLatest([this.answer$, this.acceptedGuesses$]).pipe(
       map(([answer, acceptedGuesses]) => {
         const correctLetters: string[] = acceptedGuesses.map(guess =>
@@ -92,13 +92,13 @@ export class GamePlayService {
         ).flat();
         const usedLetters: string[] = [...new Set(acceptedGuesses.join(''))];
 
-        if (!usedLetters.includes(key)) return KeyScore.unused;
+        if (!usedLetters.includes(key)) return LetterScore.scoreless;
 
-        if (correctLetters.includes(key)) return KeyScore.correct;
+        if (correctLetters.includes(key)) return LetterScore.correct;
 
-        if (answer.word.includes(key)) return KeyScore.inWord;
+        if (answer.word.includes(key)) return LetterScore.inWord;
 
-        return KeyScore.notInWord;
+        return LetterScore.notInWord;
       })
     );
   }

--- a/src/app/services/game-play.service.ts
+++ b/src/app/services/game-play.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, combineLatest, take } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 
 import { AnswerService } from './answer.service';
@@ -99,8 +99,7 @@ export class GamePlayService {
         if (answer.word.includes(key)) return KeyScore.inWord;
 
         return KeyScore.notInWord;
-      }),
-      take(1)
+      })
     );
   }
 


### PR DESCRIPTION
Adds:
* `KeyColor` enum
* `constructor(){}` to `KeyComponent` to use `GamePlayService`
* `keyColor$` to `KeyComponent`, which is set `OnInit` by  `GamePlayService.evaluateKey$(key)`
* Styling classes `.light-grey`, `.dark-grey`, `.green`, `.yellow`
* Conditional color classes on `<button/>` element in `KeyComponent` HTML

Updates:
* `KeyComponent` Testing to test `ENTER`, `DELETE`, `A` and `Q` key inputs
* `KeyComponent` and `KeyBoard` Test Suites to import `HttpClientTestingModule`

Question: Do I need to do something to the observable `keyColor$` in `ngOnDestroy()`? Or is that taken care of using the async pipe `| async`?